### PR TITLE
Adjust to MirRenderSurface changes in upstream mir

### DIFF
--- a/src/platforms/android/client/android_client_platform.cpp
+++ b/src/platforms/android/client/android_client_platform.cpp
@@ -393,7 +393,7 @@ std::shared_ptr<mcl::ClientBufferFactory> mcla::AndroidClientPlatform::create_bu
 void mcla::AndroidClientPlatform::use_egl_native_window(std::shared_ptr<void> native_window, EGLNativeSurface* surface)
 {
     auto anw = std::static_pointer_cast<mga::MirNativeWindow>(native_window);
-    anw->use_native_surface(std::make_shared<mcla::EGLNativeSurfaceInterpreter>(*surface));
+    static_cast<mcla::EGLNativeSurfaceInterpreter&>(anw->interpreter()).set_surface(surface);
 }
 
 std::shared_ptr<void> mcla::AndroidClientPlatform::create_egl_native_window(EGLNativeSurface* surface)
@@ -406,13 +406,10 @@ std::shared_ptr<void> mcla::AndroidClientPlatform::create_egl_native_window(EGLN
     else
         report = std::make_shared<mga::NullNativeWindowReport>();
 
-    std::shared_ptr<mga::AndroidDriverInterpreter> surface_interpreter;
-    if (surface)
-        surface_interpreter = std::make_shared<mcla::EGLNativeSurfaceInterpreter>(*surface);
-    else
-        surface_interpreter = std::make_shared<mcla::ErrorDriverInterpreter>();
-
-    return std::make_shared<mga::MirNativeWindow>(surface_interpreter, report);
+    auto interpreter = std::make_shared<mcla::EGLNativeSurfaceInterpreter>(surface);
+    std::shared_ptr<void> ret = std::make_shared<mga::MirNativeWindow>(interpreter, report);
+    interpreter->set_native_key(ret.get());
+    return ret;
 }
 
 std::shared_ptr<EGLNativeDisplayType>

--- a/src/platforms/android/common/mir_native_window.cpp
+++ b/src/platforms/android/common/mir_native_window.cpp
@@ -330,8 +330,7 @@ catch (std::exception const& e)
     return -1;
 }
 
-void mga::MirNativeWindow::use_native_surface(
-    std::shared_ptr<AndroidDriverInterpreter> const& interpreter)
+mga::AndroidDriverInterpreter& mga::MirNativeWindow::interpreter()
 {
-    driver_interpreter = interpreter;
+    return *driver_interpreter;
 }

--- a/src/platforms/android/include/mir_native_window.h
+++ b/src/platforms/android/include/mir_native_window.h
@@ -50,9 +50,9 @@ public:
     int cancelBuffer(struct ANativeWindowBuffer* buffer, int fence);
     int cancelBufferDeprecated(struct ANativeWindowBuffer* buffer);
     int setSwapInterval(int interval);
-    void use_native_surface(std::shared_ptr<AndroidDriverInterpreter> const& interpreter);
+    AndroidDriverInterpreter& interpreter();
 private:
-    std::shared_ptr<AndroidDriverInterpreter> driver_interpreter;
+    std::shared_ptr<AndroidDriverInterpreter> const driver_interpreter;
     std::shared_ptr<NativeWindowReport> const report;
     std::shared_ptr<SyncFileOps> const sync_ops;
     std::vector<struct ANativeWindowBuffer*> cancelled_buffers;

--- a/tests/unit-tests/platforms/android/client/test_android_native_window.cpp
+++ b/tests/unit-tests/platforms/android/client/test_android_native_window.cpp
@@ -74,22 +74,6 @@ protected:
 
 }
 
-TEST_F(AndroidNativeWindowTest, use_native_surface_call_replaces_existing_interpreter)
-{
-    std::shared_ptr<MockAndroidDriverInterpreter> const new_driver_interpreter =
-        std::make_shared<NiceMock<MockAndroidDriverInterpreter>>();
-
-    // Test that the call goes to the new interpreter instead of the old one
-    EXPECT_CALL(*mock_driver_interpreter, sync_to_display(true))
-        .Times(0);
-
-    EXPECT_CALL(*new_driver_interpreter, sync_to_display(true))
-        .Times(1);
-
-    mir_native_window.use_native_surface(new_driver_interpreter);
-    window.setSwapInterval(&window, 1);
-}
-
 TEST_F(AndroidNativeWindowTest, native_window_swapinterval)
 {
     ASSERT_NE(nullptr, window.setSwapInterval);

--- a/tests/unit-tests/platforms/android/client/test_egl_native_surface_interpreter.cpp
+++ b/tests/unit-tests/platforms/android/client/test_egl_native_surface_interpreter.cpp
@@ -86,7 +86,7 @@ TEST_F(AndroidInterpreter, gets_buffer_via_the_surface_on_request)
 {
     using namespace testing;
     testing::NiceMock<MockMirSurface> mock_surface{surf_params};
-    mcla::EGLNativeSurfaceInterpreter interpreter(mock_surface);
+    mcla::EGLNativeSurfaceInterpreter interpreter(&mock_surface);
 
     EXPECT_CALL(mock_surface, get_current_buffer()).Times(1).WillOnce(Return(mock_client_buffer));
 
@@ -99,7 +99,7 @@ TEST_F(AndroidInterpreter, gets_native_handle_from_returned_buffer)
     auto buffer = std::make_shared<mtd::StubAndroidNativeBuffer>();
 
     testing::NiceMock<MockMirSurface> mock_surface{surf_params};
-    mcla::EGLNativeSurfaceInterpreter interpreter(mock_surface);
+    mcla::EGLNativeSurfaceInterpreter interpreter(&mock_surface);
 
     EXPECT_CALL(*mock_client_buffer, native_buffer_handle()).Times(1).WillOnce(Return(buffer));
     EXPECT_CALL(mock_surface, get_current_buffer()).Times(1).WillOnce(Return(mock_client_buffer));
@@ -114,7 +114,7 @@ TEST_F(AndroidInterpreter, advances_surface_on_buffer_return)
     ANativeWindowBuffer buffer;
 
     testing::NiceMock<MockMirSurface> mock_surface{surf_params};
-    mcla::EGLNativeSurfaceInterpreter interpreter(mock_surface);
+    mcla::EGLNativeSurfaceInterpreter interpreter(&mock_surface);
 
     EXPECT_CALL(mock_surface, swap_buffers_sync()).Times(1);
 
@@ -126,7 +126,7 @@ TEST_F(AndroidInterpreter, remembers_format)
 {
     int format = 945;
     testing::NiceMock<MockMirSurface> mock_surface{surf_params};
-    mcla::EGLNativeSurfaceInterpreter interpreter(mock_surface);
+    mcla::EGLNativeSurfaceInterpreter interpreter(&mock_surface);
 
     interpreter.dispatch_driver_request_format(format);
     auto tmp_format = interpreter.driver_requests_info(NATIVE_WINDOW_FORMAT);
@@ -137,7 +137,7 @@ TEST_F(AndroidInterpreter, remembers_format)
 TEST_F(AndroidInterpreter, returns_no_transform_for_transform_hint_query)
 {
     testing::NiceMock<MockMirSurface> mock_surface{surf_params};
-    mcla::EGLNativeSurfaceInterpreter interpreter(mock_surface);
+    mcla::EGLNativeSurfaceInterpreter interpreter(&mock_surface);
     /* transform hint is a bitmask of a few options for rotation/flipping buffer. a value
        of zero is no transform */
     int transform_hint_zero = 0;
@@ -149,7 +149,7 @@ TEST_F(AndroidInterpreter, returns_no_transform_for_transform_hint_query)
 TEST_F(AndroidInterpreter, returns_width_as_default_width)
 {
     testing::NiceMock<MockMirSurface> mock_surface{surf_params};
-    mcla::EGLNativeSurfaceInterpreter interpreter(mock_surface);
+    mcla::EGLNativeSurfaceInterpreter interpreter(&mock_surface);
 
     auto default_width = interpreter.driver_requests_info(NATIVE_WINDOW_DEFAULT_WIDTH);
 
@@ -159,7 +159,7 @@ TEST_F(AndroidInterpreter, returns_width_as_default_width)
 TEST_F(AndroidInterpreter, returns_height_as_default_height)
 {
     testing::NiceMock<MockMirSurface> mock_surface{surf_params};
-    mcla::EGLNativeSurfaceInterpreter interpreter(mock_surface);
+    mcla::EGLNativeSurfaceInterpreter interpreter(&mock_surface);
 
     auto default_height = interpreter.driver_requests_info(NATIVE_WINDOW_DEFAULT_HEIGHT);
 
@@ -169,7 +169,7 @@ TEST_F(AndroidInterpreter, returns_height_as_default_height)
 TEST_F(AndroidInterpreter, returns_surface_as_concrete_type)
 {
     testing::NiceMock<MockMirSurface> mock_surface{surf_params};
-    mcla::EGLNativeSurfaceInterpreter interpreter(mock_surface);
+    mcla::EGLNativeSurfaceInterpreter interpreter(&mock_surface);
 
     auto concrete_type = interpreter.driver_requests_info(NATIVE_WINDOW_CONCRETE_TYPE);
     EXPECT_EQ(NATIVE_WINDOW_SURFACE, concrete_type);
@@ -178,7 +178,7 @@ TEST_F(AndroidInterpreter, returns_surface_as_concrete_type)
 TEST_F(AndroidInterpreter, returns_width)
 {
     testing::NiceMock<MockMirSurface> mock_surface{surf_params};
-    mcla::EGLNativeSurfaceInterpreter interpreter(mock_surface);
+    mcla::EGLNativeSurfaceInterpreter interpreter(&mock_surface);
 
     auto width = interpreter.driver_requests_info(NATIVE_WINDOW_WIDTH);
 
@@ -188,7 +188,7 @@ TEST_F(AndroidInterpreter, returns_width)
 TEST_F(AndroidInterpreter, returns_height)
 {
     testing::NiceMock<MockMirSurface> mock_surface{surf_params};
-    mcla::EGLNativeSurfaceInterpreter interpreter(mock_surface);
+    mcla::EGLNativeSurfaceInterpreter interpreter(&mock_surface);
 
     auto height = interpreter.driver_requests_info(NATIVE_WINDOW_HEIGHT);
 
@@ -205,7 +205,7 @@ TEST_F(AndroidInterpreter, returns_height)
 TEST_F(AndroidInterpreter, returns_2_for_min_undequeued_query)
 {
     testing::NiceMock<MockMirSurface> mock_surface{surf_params};
-    mcla::EGLNativeSurfaceInterpreter interpreter(mock_surface);
+    mcla::EGLNativeSurfaceInterpreter interpreter(&mock_surface);
 
     auto num_buffers = interpreter.driver_requests_info(NATIVE_WINDOW_MIN_UNDEQUEUED_BUFFERS);
     EXPECT_EQ(2, num_buffers);
@@ -218,7 +218,7 @@ TEST_F(AndroidInterpreter, requests_swapinterval_change)
     EXPECT_CALL(mock_surface, request_and_wait_for_configure(mir_window_attrib_swapinterval, 1));
     EXPECT_CALL(mock_surface, request_and_wait_for_configure(mir_window_attrib_swapinterval, 0));
 
-    mcla::EGLNativeSurfaceInterpreter interpreter(mock_surface);
+    mcla::EGLNativeSurfaceInterpreter interpreter(&mock_surface);
     interpreter.sync_to_display(true);
     interpreter.sync_to_display(false);
 }
@@ -228,7 +228,7 @@ TEST_F(AndroidInterpreter, request_to_set_buffer_count_sets_cache_size)
     int new_size = 5;
     testing::NiceMock<MockMirSurface> mock_surface{surf_params};
     EXPECT_CALL(mock_surface, set_buffer_cache_size(new_size));
-    mcla::EGLNativeSurfaceInterpreter interpreter(mock_surface);
+    mcla::EGLNativeSurfaceInterpreter interpreter(&mock_surface);
     interpreter.dispatch_driver_request_buffer_count(new_size);
 }
 
@@ -241,7 +241,7 @@ TEST_F(AndroidInterpreter, returns_proper_usage_bits_based_on_surface)
     MirWindowParameters const hardware = {"", 1, 2, mir_pixel_format_abgr_8888, mir_buffer_usage_hardware, 0};
 #pragma GCC diagnostic pop
     testing::NiceMock<MockMirSurface> mock_surface{surf_params};
-    mcla::EGLNativeSurfaceInterpreter interpreter(mock_surface);
+    mcla::EGLNativeSurfaceInterpreter interpreter(&mock_surface);
 
     EXPECT_CALL(mock_surface, get_parameters()).Times(2).WillOnce(Return(software)).WillOnce(Return(hardware));
 
@@ -257,7 +257,7 @@ TEST_F(AndroidInterpreter, request_to_set_buffer_size_ignores_duplicate_sizing_r
     geom::Size new_size{10, 12};
     testing::NiceMock<MockMirSurface> mock_surface{surf_params};
     EXPECT_CALL(mock_surface, set_size(new_size));
-    mcla::EGLNativeSurfaceInterpreter interpreter(mock_surface);
+    mcla::EGLNativeSurfaceInterpreter interpreter(&mock_surface);
     interpreter.dispatch_driver_request_buffer_size({surf_params.width, surf_params.height});
     interpreter.dispatch_driver_request_buffer_size(new_size);
 }
@@ -266,7 +266,7 @@ TEST_F(AndroidInterpreter, sets_pixelformat_via_driver_request)
 {
     using namespace testing;
     NiceMock<MockMirSurface> mock_surface{surf_params};
-    mcla::EGLNativeSurfaceInterpreter interpreter(mock_surface);
+    mcla::EGLNativeSurfaceInterpreter interpreter(&mock_surface);
     int android_pixel_format = 34;
     interpreter.dispatch_driver_request_format(android_pixel_format);
     EXPECT_THAT(interpreter.driver_requests_info(NATIVE_WINDOW_FORMAT), Eq(android_pixel_format));
@@ -276,7 +276,7 @@ TEST_F(AndroidInterpreter, denies_attempt_to_reset_the_buffer_format)
 {
     using namespace testing;
     NiceMock<MockMirSurface> mock_surface{surf_params};
-    mcla::EGLNativeSurfaceInterpreter interpreter(mock_surface);
+    mcla::EGLNativeSurfaceInterpreter interpreter(&mock_surface);
     const int android_pixel_format = 13;
     interpreter.dispatch_driver_request_format(android_pixel_format);
     const int other_android_pixel_format = 2;
@@ -289,7 +289,7 @@ TEST_F(AndroidInterpreter, replies_to_dataspace_query)
 {
     using namespace testing;
     NiceMock<MockMirSurface> mock_surface{surf_params};
-    mcla::EGLNativeSurfaceInterpreter interpreter(mock_surface);
+    mcla::EGLNativeSurfaceInterpreter interpreter(&mock_surface);
     EXPECT_THAT(interpreter.driver_requests_info(NATIVE_WINDOW_DEFAULT_DATASPACE), Eq(HAL_DATASPACE_UNKNOWN));
 }
 
@@ -297,7 +297,7 @@ TEST_F(AndroidInterpreter, pulls_buffer_age_out_of_last_buffer)
 {
     using namespace testing;
     NiceMock<MockMirSurface> mock_surface{surf_params};
-    mcla::EGLNativeSurfaceInterpreter interpreter(mock_surface);
+    mcla::EGLNativeSurfaceInterpreter interpreter(&mock_surface);
     ON_CALL(mock_surface, get_current_buffer()).WillByDefault(Return(mock_surface.client_buffer));
     EXPECT_THAT(interpreter.driver_requests_info(NATIVE_WINDOW_BUFFER_AGE), Eq(0));
 


### PR DESCRIPTION
MirRenderSurface now abstracts the buffer passing mechanism from the client
API user. Thus the client never creates a buffer stream instance. This has
to happen in the platform. Thus EGLNativeSurfaceInterpreter uses the
MirRenderSurface to create a buffer stream instance.