### PR TITLE
Set inital format when creating gralloc buffer

### DIFF
--- a/src/platforms/android/client/gralloc_registrar.cpp
+++ b/src/platforms/android/client/gralloc_registrar.cpp
@@ -22,6 +22,8 @@
 #include "sync_fence.h"
 #include "gralloc_registrar.h"
 #include "mir/client/client_buffer.h"
+#include "android_format_conversion-inl.h"
+
 
 #include <boost/throw_exception.hpp>
 #include <stdexcept>
@@ -82,6 +84,7 @@ std::shared_ptr<mga::NativeBuffer> create_native_buffer(
     //about byte-stride, they will pass stride via ANativeWindowBuffer::handle (which is opaque to us)
     anwb->stride = package.stride / MIR_BYTES_PER_PIXEL(pf);
     anwb->usage = GRALLOC_USAGE_HW_TEXTURE | GRALLOC_USAGE_HW_RENDER;
+    anwb->format = mga::to_android_format(pf);
     anwb->handle = handle.get();
 
     auto sync = std::make_shared<mg::NullCommandSync>(); //no need for eglsync client side


### PR DESCRIPTION
Not sure why it didn't get set before (maybe never needed it), but this sets it when we create the buffer. This makes sure the buffer format is set before we use the buffer. 

Why it worked sometimes, I got no idea.

This fixes the issue we had with mir 1.1 :)