### PR TITLE
Initialize fake SurfaceFlinger from libminisf if present

### DIFF
--- a/cmake/FindLibHardware.cmake
+++ b/cmake/FindLibHardware.cmake
@@ -11,7 +11,12 @@ find_library(LIBHARDWARE_LIBRARY
                  libhardware.so
 )
 
-set(LIBHARDWARE_LIBRARIES ${LIBHARDWARE_LIBRARY})
+find_library(LIBHYBRIS_COMMON_LIBRARY
+   NAMES         libhybris-common.so.1
+                 libhybris-common.so
+)
+
+set(LIBHARDWARE_LIBRARIES ${LIBHARDWARE_LIBRARY} ${LIBHYBRIS_COMMON_LIBRARY})
 
 # handle the QUIETLY and REQUIRED arguments and set LIBHARDWARE_FOUND to TRUE
 # if all listed variables are TRUE

--- a/src/platforms/android/server/hal_component_factory.cpp
+++ b/src/platforms/android/server/hal_component_factory.cpp
@@ -34,7 +34,11 @@
 #include "android_format_conversion-inl.h"
 
 #include <boost/throw_exception.hpp>
+#include <dlfcn.h>
 #include <stdexcept>
+
+#define MIR_LOG_COMPONENT "android/server"
+#include "mir/log.h"
 
 namespace mg = mir::graphics;
 namespace mga = mir::graphics::android;
@@ -67,6 +71,7 @@ mga::HalComponentFactory::HalComponentFactory(
         num_framebuffers = std::max(2u, static_cast<unsigned int>(fb_native->numFramebuffers));
     }
 
+    start_fake_surfaceflinger();
     command_stream_sync_factory = create_command_stream_sync_factory();
     buffer_allocator = std::make_shared<mga::GraphicBufferAllocator>(
         command_stream_sync_factory, quirks);
@@ -173,4 +178,33 @@ std::unique_ptr<mga::HwcConfiguration> mga::HalComponentFactory::create_hwc_conf
 std::shared_ptr<mg::GraphicBufferAllocator> mga::HalComponentFactory::the_buffer_allocator()
 {
     return buffer_allocator;
+}
+
+extern "C" void *android_dlopen(const char *filename, int flags);
+extern "C" void *android_dlsym(void *handle, const char *symbol);
+
+void mga::HalComponentFactory::start_fake_surfaceflinger()
+{
+    // Adapted from mer-hybris/qt5-qpa-hwcomposer plugin
+    void *libminisf;
+    void (*startMiniSurfaceFlinger)(void) = NULL;
+
+    // A reason for calling this method here is to initialize the binder
+    // thread pool such that services started from for example the
+    // hwcomposer plugin don't get stuck.
+    // Another is to have the SurfaceFlinger service in the same process
+    // as hwcomposer, on some devices this could improve performance.
+
+    libminisf = android_dlopen("libminisf.so", RTLD_LAZY);
+
+    if (libminisf) {
+        startMiniSurfaceFlinger = (void(*)(void))android_dlsym(libminisf, "startMiniSurfaceFlinger");
+    }
+
+    if (startMiniSurfaceFlinger) {
+        startMiniSurfaceFlinger();
+        mir::log_info("Started fake SurfaceFlinger service");
+    } else {
+        mir::log_info("Device does not have libminisf or it is incompatible, not starting fake SurfaceFlinger service");
+    }
 }

--- a/src/platforms/android/server/hal_component_factory.h
+++ b/src/platforms/android/server/hal_component_factory.h
@@ -59,6 +59,7 @@ public:
 
 private:
     std::unique_ptr<CommandStreamSyncFactory> create_command_stream_sync_factory();
+    void start_fake_surfaceflinger();
 
     std::shared_ptr<DisplayResourceFactory> const res_factory;
     std::shared_ptr<HwcReport> const hwc_report;


### PR DESCRIPTION
This implements the same change as https://github.com/ubports/mir/pull/13

Original commit message:
Ported from from mer-hybris/qt5-qpa-hwcomposer-plugin@c986132 and needed for Gemini PDA camera to work.

It should help with other Android 7 devices as well, as halium-7.1 does not have the following commit:
ubports/android_frameworks_native@ac0afed7230dfc01c26150956299b3c2643f70de. It is not needed with libminsf from sailfishos/drodmedia, as ISurfaceComposer is provided (simply porting that commit is not enough at least for Gemini).