### PR TITLE
WIP: DisplayGroup: allow commit() to fail for a few times

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,13 @@
+String stashFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.dsc,*.changes,*.buildinfo,lintian.txt'
+String archiveFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.dsc,*.changes,*.buildinfo'
+
 pipeline {
   agent any
   stages {
     stage('Build source') {
       steps {
         sh '/usr/bin/build-source.sh'
-        stash(name: 'source', includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt')
+        stash(name: 'source', includes: stashFileList)
         cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
       }
     }
@@ -17,7 +20,7 @@ pipeline {
               unstash 'source'
               sh '''export architecture="armhf"
 build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-armhf')
+              stash(includes: stashFileList, name: 'build-armhf')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
 
@@ -29,7 +32,7 @@ build-binary.sh'''
               unstash 'source'
               sh '''export architecture="arm64"
     build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-arm64')
+              stash(includes: stashFileList, name: 'build-arm64')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
           },
@@ -39,7 +42,7 @@ build-binary.sh'''
               unstash 'source'
               sh '''export architecture="amd64"
     build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-amd64')
+              stash(includes: stashFileList, name: 'build-amd64')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
           }
@@ -52,7 +55,7 @@ build-binary.sh'''
         unstash 'build-armhf'
         unstash 'build-arm64'
         unstash 'build-amd64'
-        archiveArtifacts(artifacts: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo', fingerprint: true, onlyIfSuccessful: true)
+        archiveArtifacts(artifacts: archiveFileList, fingerprint: true, onlyIfSuccessful: true)
         sh '''/usr/bin/build-repo.sh'''
       }
     }

--- a/src/platforms/android/server/display_group.h
+++ b/src/platforms/android/server/display_group.h
@@ -62,6 +62,7 @@ private:
     std::shared_ptr<DisplayDevice> const device;
     std::map<DisplayName, std::unique_ptr<ConfigurableDisplayBuffer>> dbs;
     ExceptionHandler const exception_handler;
+    int commit_failure_count;
 };
 
 }


### PR DESCRIPTION
Commit() can fails for a transient reason. For example, if a client
disconnects between the content list is submitted and hwc->set() is
called, it will fails.

Usually, the next call should fix the problem, but if it happens more
than 3 times in a row, it may indicates that the problem is, in fact,
not transient. In this case, we'll forward the exception up the call
stack, which will then terminate the server.