### PR TITLE
[display] Do not perserve buffers when display changes

### DIFF
--- a/src/platforms/android/server/display.cpp
+++ b/src/platforms/android/server/display.cpp
@@ -356,7 +356,9 @@ bool mga::Display::apply_if_configuration_preserves_display_buffers(
      */
     std::lock_guard<decltype(configuration_mutex)> lock{configuration_mutex};
     if ((!config.external().connected && displays.display_present(mga::DisplayName::external)) ||
-       (config.external().connected && !displays.display_present(mga::DisplayName::external)))
+       (config.external().connected && !displays.display_present(mga::DisplayName::external)) ||
+       (!config.virt().connected && displays.display_present(mga::DisplayName::virt)) ||
+       (config.virt().connected && !displays.display_present(mga::DisplayName::virt)))
         return false;
 
     configure_locked(conf, lock);

--- a/src/platforms/android/server/display.cpp
+++ b/src/platforms/android/server/display.cpp
@@ -348,20 +348,19 @@ bool mga::Display::apply_if_configuration_preserves_display_buffers(
     /*
      * We never invalidate display buffers based on the configuration to apply.
      *
-     * The only way we invalidate a display buffer is if we detect that a previously-connected
-     * external display has been removed. In that case, regardless of whether or not it's enabled
-     * in the configuration, we destroy the display.
+     * The only way we invalidate a display buffer is if we detect that a display has
+     * been connected or disconnected
      *
      * Take the configuration lock to ensure consistency between our checking for external
      * connections and configure's checking.
      */
     std::lock_guard<decltype(configuration_mutex)> lock{configuration_mutex};
-    if (!config.external().connected || displays.display_present(mga::DisplayName::external))
-    {
-        configure_locked(conf, lock);
-        return true;
-    }
-    return false;
+    if ((!config.external().connected && displays.display_present(mga::DisplayName::external)) ||
+       (config.external().connected && !displays.display_present(mga::DisplayName::external)))
+        return false;
+
+    configure_locked(conf, lock);
+    return true;
 }
 
 void mga::Display::configure_locked(

--- a/src/platforms/android/server/display.h
+++ b/src/platforms/android/server/display.h
@@ -105,6 +105,7 @@ private:
     std::unique_ptr<HwcConfiguration> const hwc_config;
     ConfigChangeSubscription const hotplug_subscription;
     DisplayConfiguration mutable config;
+    DisplayOutputConnections old_outputs;
     PbufferGLContext gl_context;
     std::shared_ptr<DisplayDevice> display_device;
     std::unique_ptr<DisplayChangePipe> display_change_pipe;

--- a/src/platforms/android/server/display_configuration.cpp
+++ b/src/platforms/android/server/display_configuration.cpp
@@ -256,6 +256,17 @@ mg::DisplayConfigurationOutput& mga::DisplayConfiguration::operator[](mg::Displa
     return configurations[id];
 }
 
+const mga::DisplayOutputConnections mga::DisplayConfiguration::output_connections()
+{
+    return DisplayOutputConnections{primary().connected,
+                                    external().connected,
+#ifdef ANDROID_CAF
+                                    tertiary().connected,
+#endif
+                                    virt().connected};
+}
+
+
 void mga::DisplayConfiguration::set_virtual_output_to(int width, int height)
 {
     auto& virt_config = virt();

--- a/src/platforms/android/server/display_configuration.h
+++ b/src/platforms/android/server/display_configuration.h
@@ -28,6 +28,26 @@ namespace graphics
 namespace android
 {
 
+struct DisplayOutputConnections
+{
+    bool primary;
+    bool external;
+    bool virt;
+#ifdef ANDROID_CAF
+    bool tertiary;
+#endif
+
+    bool operator==(const DisplayOutputConnections& other) const
+    {
+        return primary == other.primary &&
+               external == other.external &&
+#ifdef ANDROID_CAF
+               tertiary == other.tertiary &&
+#endif
+               virt == other.virt;
+    }
+};
+
 class DisplayConfiguration : public graphics::DisplayConfiguration
 {
 public:
@@ -70,6 +90,8 @@ public:
 #endif
     DisplayConfigurationOutput& virt();
     DisplayConfigurationOutput& operator[](DisplayConfigurationOutputId const&);
+
+    const DisplayOutputConnections output_connections();
 
     void set_virtual_output_to(int width, int height);
     void disable_virtual_output();

--- a/tests/unit-tests/platforms/android/server/test_display.cpp
+++ b/tests/unit-tests/platforms/android/server/test_display.cpp
@@ -1140,6 +1140,10 @@ TEST_F(Display, does_not_invalidate_display_buffers_when_it_promised_not_to)
     ASSERT_THAT(virtual_output, NotNull());
     virtual_output->enable();
 
+    // Configure virtual display before we change anything else
+    // If we do not, it will think it's a display change
+    display.configure(*display.configuration());
+
     // We should be able to do everything except disable an external output.
     auto config = display.configuration();
     config->for_each_output(

--- a/tests/unit-tests/platforms/android/server/test_display.cpp
+++ b/tests/unit-tests/platforms/android/server/test_display.cpp
@@ -1139,13 +1139,13 @@ TEST_F(Display, does_not_invalidate_display_buffers_when_it_promised_not_to)
 
     ASSERT_THAT(virtual_output, NotNull());
     virtual_output->enable();
+    auto config = display.configuration();
 
     // Configure virtual display before we change anything else
     // If we do not, it will think it's a display change
-    display.configure(*display.configuration());
+    display.configure(*config);
 
-    // We should be able to do everything except disable an external output.
-    auto config = display.configuration();
+    // We should be able to do everything except disable/enable an output.
     config->for_each_output(
         [](mg::UserDisplayConfigurationOutput& output)
         {


### PR DESCRIPTION
We should *not* preserve buffers when a display/output was disconnected
or connected

If we do not do this, android will still feed us invalid buffers and/or
compositor thread tries to access destroyed buffers.

Needed for secondscreen to work