### PR TITLE
Support dataspace query on server buffer

### DIFF
--- a/src/platforms/android/server/server_render_window.cpp
+++ b/src/platforms/android/server/server_render_window.cpp
@@ -105,6 +105,8 @@ int mga::ServerRenderWindow::driver_requests_info(int key) const
             return 20;
         case NATIVE_WINDOW_LAST_DEQUEUE_DURATION:
             return 20;
+        case NATIVE_WINDOW_DEFAULT_DATASPACE:
+            return HAL_DATASPACE_V0_SRGB_LINEAR;
         default:
             {
             std::stringstream sstream;


### PR DESCRIPTION
The driver of Samsung Galaxy S7 queries the server about the dataspace attribute. Without handling that the graphics platform overreacts and tears the server down.