### PR TITLE
[server/hwc2] Use hotplug to handle screen added/removed events

### DIFF
--- a/src/platforms/android/server/real_hwc2_wrapper.h
+++ b/src/platforms/android/server/real_hwc2_wrapper.h
@@ -83,7 +83,7 @@ public:
     void set_active_config(DisplayName name, ConfigId id) const override;
 
     void vsync(DisplayName, graphics::Frame::Timestamp) noexcept;
-    void hotplug(DisplayName, bool) noexcept;
+    void hotplug(hwc2_display_t, bool, bool) noexcept;
     void invalidate() noexcept;
 
     bool display_connected(DisplayName) const;


### PR DESCRIPTION
This moves the handling of screen added and remove removed events to
hotplug(), this includes initial primary display. This also removes the
need for the hack that waits for the primary display hotplug to happend
using a for loop.