### PR TITLE
Handle/Support external display

### DIFF
--- a/src/platforms/android/server/real_hwc2_wrapper.h
+++ b/src/platforms/android/server/real_hwc2_wrapper.h
@@ -103,6 +103,8 @@ private:
     std::unordered_map<void const*, Callbacks> callback_map;
     std::atomic<bool> is_plugged[HWC_NUM_DISPLAY_TYPES];
     std::unordered_map<int, std::vector<hwc2_compat_layer_t*>> display_contents;
+    std::unordered_map<int, int> last_present_fence;
+    std::unordered_map<int, bool> active_displays;
 };
 
 }


### PR DESCRIPTION
This adds support for external display, this now works on the fx(tec) pro1! :D 

If anyone else have a device that uses hwc2 with display out support (usb-c alt mode), most usb 3.1 devices supports this can try this to get the external display goodies. 

Disconnect is still a bit flaky as we don't handle the tear down of display yet. So here be bug-dragons. 

Depends on https://github.com/ubports/mir-android-platform/pull/22