### PR TITLE
Adapt mir v1.8 changes and get mir version from pkgconfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,17 +8,8 @@ project(MirAndroidPlatform)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
-set(MIR_VERSION_MAJOR 1)
-set(MIR_VERSION_MINOR 1)
-set(MIR_VERSION_PATCH 0)
-
-add_definitions(-DMIR_VERSION_MAJOR=${MIR_VERSION_MAJOR})
-add_definitions(-DMIR_VERSION_MINOR=${MIR_VERSION_MINOR})
-add_definitions(-DMIR_VERSION_MICRO=${MIR_VERSION_PATCH})
 add_definitions(-D_GNU_SOURCE)
 add_definitions(-D_FILE_OFFSET_BITS=64)
-
-set(MIR_VERSION ${MIR_VERSION_MAJOR}.${MIR_VERSION_MINOR}.${MIR_VERSION_PATCH})
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 execute_process(
@@ -182,6 +173,19 @@ pkg_check_modules(MIRCORE REQUIRED mircore)
 pkg_check_modules(MIRPLATFORM REQUIRED mirplatform)
 pkg_check_modules(MIRGLRENDERER REQUIRED mir-renderer-gl-dev)
 pkg_check_modules(MIRRENDERER REQUIRED mirrenderer)
+
+# Set version based on mirplatform
+string(REPLACE "." ";" VERSION_LIST ${MIRPLATFORM_VERSION})
+list(GET VERSION_LIST 0 MIR_VERSION_MAJOR)
+list(GET VERSION_LIST 1 MIR_VERSION_MINOR)
+list(GET VERSION_LIST 2 MIR_VERSION_PATCH)
+
+add_definitions(-DMIR_VERSION_MAJOR=${MIR_VERSION_MAJOR})
+add_definitions(-DMIR_VERSION_MINOR=${MIR_VERSION_MINOR})
+add_definitions(-DMIR_VERSION_MICRO=${MIR_VERSION_PATCH})
+set(MIR_VERSION ${MIR_VERSION_MAJOR}.${MIR_VERSION_MINOR}.${MIR_VERSION_PATCH})
+
+message("Bulding Mir android platfrom version ${MIR_VERSION}")
 
 include_directories(
     ${PROJECT_SOURCE_DIR}

--- a/tests/include/mir/test/doubles/mock_renderable.h
+++ b/tests/include/mir/test/doubles/mock_renderable.h
@@ -21,6 +21,7 @@
 
 #include "mir/test/doubles/stub_buffer.h"
 #include <mir/graphics/renderable.h>
+#include <mir/version.h>
 #include <gmock/gmock.h>
 
 namespace mir
@@ -43,6 +44,10 @@ struct MockRenderable : public graphics::Renderable
             .WillByDefault(testing::Return(glm::mat4{{1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}}));
         ON_CALL(*this, visible())
             .WillByDefault(testing::Return(true));
+#if MIR_SERVER_VERSION >= MIR_VERSION_NUMBER(1, 5, 0)
+        ON_CALL(*this, clip_area())
+            .WillByDefault(testing::Return(std::experimental::optional<geometry::Rectangle>()));
+#endif
     }
 
     MOCK_CONST_METHOD0(id, ID());
@@ -53,6 +58,9 @@ struct MockRenderable : public graphics::Renderable
     MOCK_CONST_METHOD0(visible, bool());
     MOCK_CONST_METHOD0(shaped, bool());
     MOCK_CONST_METHOD0(swap_interval, unsigned int());
+#if MIR_SERVER_VERSION >= MIR_VERSION_NUMBER(1, 5, 0)
+    MOCK_CONST_METHOD0(clip_area, std::experimental::optional<geometry::Rectangle>());
+#endif
 };
 }
 }

--- a/tests/include/mir/test/doubles/stub_renderable.h
+++ b/tests/include/mir/test/doubles/stub_renderable.h
@@ -21,6 +21,7 @@
 
 #include "mir/test/doubles/stub_buffer.h"
 #include <mir/graphics/renderable.h>
+#include <mir/version.h>
 #include <memory>
 #define GLM_FORCE_RADIANS
 #define GLM_PRECISION_MEDIUMP_FLOAT
@@ -89,6 +90,12 @@ public:
     {
         return 1;
     }
+#if MIR_SERVER_VERSION >= MIR_VERSION_NUMBER(1, 5, 0)
+    std::experimental::optional<geometry::Rectangle> clip_area() const override
+    {
+        return std::experimental::optional<geometry::Rectangle>();
+    }
+#endif
 
 private:
     std::shared_ptr<graphics::Buffer> make_stub_buffer(geometry::Rectangle const& rect)


### PR DESCRIPTION
This adapts mir v1.8 changes and gets mir version from mirplatform pkgconfig This way we don't need to set this itself, it will automatically select the version it built against.

